### PR TITLE
replace_deprecated_helm_repos - Add bitnami repo for external-dns

### DIFF
--- a/07-external-dns/README.md
+++ b/07-external-dns/README.md
@@ -3,7 +3,7 @@
 * Install Helm: https://docs.helm.sh/using_helm/#installing-helm
 
 ```sh
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
 ```
 
@@ -16,7 +16,7 @@ kubectl create namespace external-dns
 ```
 
 ```sh
-helm upgrade --install external-dns --namespace=external-dns -f values.yaml stable/external-dns
+helm upgrade --install external-dns --namespace=external-dns -f values.yaml bitnami/external-dns
 ```
 
 * Replace occurrence of `YOUR_NAME` in nginx-test.yaml

--- a/10-nginx-ingress-controller/README.md
+++ b/10-nginx-ingress-controller/README.md
@@ -7,5 +7,6 @@ kubectl create namespace nginx-ingress
 ```
 
 ```sh
-helm upgrade --install -f values.yaml --namespace nginx-ingress --version 1.33.0 nginx-ingress stable/nginx-ingress
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm upgrade --install -f values.yaml --namespace nginx-ingress --version 1.33.0 nginx-ingress ingress-nginx/ingress-nginx
 ```

--- a/10-nginx-ingress-controller/values.yaml
+++ b/10-nginx-ingress-controller/values.yaml
@@ -5,10 +5,6 @@ controller:
   extraArgs:
     default-ssl-certificate: default/metakube-tls-certs
 
-  ## Required only if defaultBackend.enabled = false
-  ## Must be <namespace>/<service_name>
-  defaultBackendService: ""
-
   ## Name of the ingress class to route through this controller
   ingressClass: nginx
 

--- a/18-exercise/README.md
+++ b/18-exercise/README.md
@@ -5,7 +5,8 @@
 * Installation would look like:
 
 ```sh
-helm upgrade --install ghost stable/ghost -f values.yaml
+helm repo add bitnami https://charts.bitnami.com/bitnami // probably already did that
+helm upgrade --install ghost bitnami/ghost -f values.yaml
 ```
 
 Bonus:


### PR DESCRIPTION
Replace links to the deprecated helm stable repo where possible

Unfortunately some are not yet migrated to other repositories:

sealed-secrets
prometheus-operator

The elasticsearch lecture will be removed anyway so we didn't migrate it.